### PR TITLE
Move all links to centaurusinfra

### DIFF
--- a/aio/deploy/centaurus-dashboard.yaml
+++ b/aio/deploy/centaurus-dashboard.yaml
@@ -334,7 +334,7 @@ spec:
     spec:
       containers:
         - name: centaurus-dashboard
-          image: c2cengg20190034/dashboard:dev
+          image: gcr.io/workload-controller-manager/centaurus-dashboard:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 8443

--- a/aio/deploy/recommended.yaml
+++ b/aio/deploy/recommended.yaml
@@ -188,7 +188,7 @@ spec:
     spec:
       containers:
         - name: centaurus-dashboard
-          image: centaurusui/dashboard:v0.0.1
+          image: gcr.io/workload-controller-manager/centaurus-dashboard:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 8443

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       - /var/lib/postgres-data:/var/lib/postgresql/data
 
   dashboard:
-    image: c2cengg20190034/dashboard:dev  # TODO change image to "centaurus/dashboard:latest" while merging the PR
+    image: gcr.io/workload-controller-manager/centaurus-dashboard:latest  # TODO change image to "centaurus/dashboard:latest" while merging the PR
     restart: always
     environment:
       - DB_HOST=postgresdb

--- a/docs/design/centaurus-dashboard-enhancement.md
+++ b/docs/design/centaurus-dashboard-enhancement.md
@@ -1,8 +1,6 @@
 
 # Centaurus Portal Requirement & Design
 
-**Author(s)**: [Click2Cloud Inc](https://github.com/Click2Cloud-Centaurus)
-
 This design document is a proposal for enhancing the dashboard UI that
 allows users to manage Centaurus Cluster, Tenants, Users, and
 Quotas in an intuitive way.

--- a/docs/developer/centaurus-dashboard-deployment-using-yaml.md
+++ b/docs/developer/centaurus-dashboard-deployment-using-yaml.md
@@ -84,7 +84,7 @@ openssl genrsa -out certs/dashboard.key 2048
 openssl rsa -in certs/dashboard.key -out certs/dashboard.key
 openssl req -sha256 -new -key certs/dashboard.key -out certs/dashboard.csr -subj "/CN=$(hostname -i | awk '{print $1}')"
 openssl x509 -req -sha256 -days 365 -in certs/dashboard.csr -signkey certs/dashboard.key -out certs/dashboard.crt
-wget https://raw.githubusercontent.com/Click2Cloud-Centaurus/Documentation/main/deployment_scripts/docker-compose.yml
+wget https://github.com/CentaurusInfra/dashboard/blob/centaurus/docker-compose.yaml
 # TODO remove above link and use "wget https://raw.githubusercontent.com/CentaurusInfra/dashboard/centaurus/docker-compose.yaml"
 docker-compose up -d
 ```

--- a/docs/developer/create-docker-image-guide.md
+++ b/docs/developer/create-docker-image-guide.md
@@ -17,7 +17,7 @@ Make sure the following software is installed and added to the $PATH variable:
 2. Clone the repository.
 
 ```bash
-git clone https://github.com/Click2Cloud-Centaurus/dashboard.git $HOME/dashboard -b centaurus
+git clone https://github.com/CentaurusInfra/dashboard.git $HOME/dashboard -b centaurus
 # TODO while merging PR change it to "git clone https://github.com/CentaurusInfra/dashboard.git $HOME/dashboard -b centaurus
 cd $HOME/dashboard
 ```

--- a/docs/developer/dashboard-deployment-guide.md
+++ b/docs/developer/dashboard-deployment-guide.md
@@ -17,7 +17,7 @@ Make sure the following software is installed and added to the $PATH variable:
 2. Clone the repository.
 
 ```bash
-git clone https://github.com/Click2Cloud-Centaurus/dashboard.git $HOME/dashboard -b dev-21
+git clone https://github.com/CentaurusInfra/dashboard.git $HOME/dashboard -b dev-21
 # TODO while merging PR change it to "git clone https://github.com/CentaurusInfra/dashboard.git $HOME/dashboard -b centaurus
 cd $HOME/dashboard
 ```


### PR DESCRIPTION
1. move all links from Click2Cloud-Centaurus to CentaurusInfra

2. change build image to  gcr.io/workload-controller-manager/centaurus-dashboard:latest